### PR TITLE
Fix memory leaks + arm 32bit

### DIFF
--- a/code/codegen.c
+++ b/code/codegen.c
@@ -20,9 +20,11 @@
 #include "json.h"
 
 #ifdef _WIN32
-#define DEBUG_BREAK __debugbreak()
+    #define DEBUG_BREAK __debugbreak()
+#elif defined(__GNUC__) && (defined(__x86_64__) || defined(__i386__))
+    #define DEBUG_BREAK __asm("int3")
 #else
-#define DEBUG_BREAK __asm("int3")
+    #define DEBUG_BREAK __builtin_trap()
 #endif
 
 // Twitter API endpoint descriptions

--- a/code/tokenizer.c
+++ b/code/tokenizer.c
@@ -83,7 +83,8 @@ static token GetToken(tokenizer* Tokenizer)
     EatAllWhitespace(Tokenizer);
 
     token Token = {0};
-    switch(*Tokenizer->At) 
+    int C = *Tokenizer->At;
+    switch(C) 
     {
         case EOF:
         case '\0': 

--- a/code/twitter.c
+++ b/code/twitter.c
@@ -941,7 +941,12 @@ twc_Media_Upload(twc_state* State, twc_in char* Filename, twc_in twc_buffer File
         curl_easy_setopt(State->cURL, CURLOPT_HTTPHEADER, OAuthHeaderList);
     }
 
-    if (curl_easy_perform(State->cURL) == CURLE_OK)
+    bool PerformSuccess = curl_easy_perform(State->cURL) == CURLE_OK;
+
+    curl_formfree(FormPost);
+    curl_slist_free_all(OAuthHeaderList);
+
+    if (PerformSuccess)
     {
         // Transfer complete, write function should be done writing
         twc_buffer Data = twc_ConsumeData(State);

--- a/code/twitter.c
+++ b/code/twitter.c
@@ -20,10 +20,6 @@
 #define twc_malloc(n) State->MemAllocFunc(n)
 #define twc_free(m) State->MemFreeFunc(m)
 
-// Even though it's declared inline in the header, GCC (and others?) may need an
-// extern declaration so they know in which TU to put the generated code.
-extern twc_string twc_ToString(const char* CString);
-
 const char* twc_HttpMethodString[3] = {
     "GET",
     "POST",
@@ -819,7 +815,7 @@ twc_GenerateOAuthHeader(twc_in twc_http_method ReqType, twc_in char* BaseURL, tw
 
     char Timestamp[22]; // Enough to hold a 64-bit number in base 10
     memset(Timestamp, '\0', sizeof(Timestamp));
-    snprintf(Timestamp, 22, "%"PRIu64, time(NULL));
+    snprintf(Timestamp, 22, "%"PRIu64, (uint64_t)time(NULL));
 
     twc_key_value_list AllParams = ParamsSorted;
 


### PR DESCRIPTION
I removed the stuff at [code/twitter.c:23](https://github.com/Chronister/twc/pull/10/commits/f96fe83b1ecd7e747aa61e7e94bb3b1a1d4e6c24#diff-b23296703164945e7ecd00549a6bd8b2L23) since it caused a multiple definition error when compiling on the pi, and it seems to work fine on my desktop without it also.